### PR TITLE
Fix player control logic for all edge cases

### DIFF
--- a/next/nextPlayer.js
+++ b/next/nextPlayer.js
@@ -18,25 +18,30 @@ function togglePlay() {
 }
 
 function nextTrack() {
+    const wasPlaying = !audioPlayer.paused;
     currentTrack = (currentTrack + 1) % tracks.length;
-    updateTrack();
+    updateTrack(wasPlaying);
 }
 
 function prevTrack() {
+    const wasPlaying = !audioPlayer.paused;
     currentTrack = (currentTrack - 1 + tracks.length) % tracks.length;
-    updateTrack();
+    updateTrack(wasPlaying);
 }
 
-function updateTrack() {
+function updateTrack(shouldPlay = false) {
     let track = tracks[currentTrack];
     let url = new URL(track.url);
     url.searchParams.set('dl', '1'); // Ensure the URL has dl=1
     audioPlayer.src = url.toString();
-    trackTitle.textContent = `Track: ${track.song} - Artist: ${track.artist}`;
+    trackTitle.textContent = `${track.song} - ${track.artist}`;
     audioPlayer.load();
-    //audioPlayer.play();
-    //playPauseBtn.textContent = "⏸ Pause";
-    //document.querySelectorAll('.reel').forEach(reel => reel.style.animationPlayState = 'running');
+
+    if (shouldPlay) {
+        audioPlayer.play();
+        playPauseBtn.textContent = "⏸ Pause";
+        document.querySelectorAll('.reel').forEach(reel => reel.style.animationPlayState = 'running');
+    }
 }
 
 function firstTrack() {
@@ -47,6 +52,22 @@ function firstTrack() {
     trackTitle.textContent = `${track.song} - ${track.artist}`;
     audioPlayer.load();
 }
+
+// Handle track ending
+audioPlayer.addEventListener('ended', () => {
+    // Check if this is the last track
+    if (currentTrack === tracks.length - 1) {
+        // Last track finished - reset to first track and stop
+        currentTrack = 0;
+        updateTrack(false);
+        playPauseBtn.textContent = "▶ Play";
+        document.querySelectorAll('.reel').forEach(reel => reel.style.animationPlayState = 'paused');
+    } else {
+        // Not the last track - auto-play next
+        currentTrack = (currentTrack + 1) % tracks.length;
+        updateTrack(true);
+    }
+});
 
 document.addEventListener('DOMContentLoaded', () => {
     firstTrack();


### PR DESCRIPTION
## Summary
Fixes all player control edge cases to ensure correct behavior for play/pause/prev/next interactions and end-of-playlist handling.

## Changes
- Modified `nextTrack()` and `prevTrack()` to preserve playing state when changing tracks
- Updated `updateTrack()` to accept `shouldPlay` parameter for conditional auto-play
- Added 'ended' event listener for proper auto-play behavior
- Last track now resets to first track and stops playback correctly
- Non-last tracks auto-advance and continue playing
- Wheels and button text now correctly sync with playback state in all scenarios

## Test plan
- [x] Play button works correctly on initial page load
- [x] Pause button stops playback and wheels
- [x] Prev/Next while stopped only changes track listing
- [x] Prev/Next while playing continues playback with new track
- [x] Wheels only spin when track is playing
- [x] Button text matches playing state
- [x] Tracks auto-advance through playlist
- [x] Last track resets to first and stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)