### PR TITLE
Add handwriting/graffiti font to active track display

### DIFF
--- a/next/index.html
+++ b/next/index.html
@@ -20,6 +20,9 @@
     <meta name="twitter:description" value="Tunes for the season, 2024" />
     <meta name="twitter:image" content="https://awintrymix.net/2024/social_2024.jpg" />
     <meta name="twitter:url" value="https://awintrymix.net/2024" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="nextTape.css">
     </link>
 </head>

--- a/next/nextTape.css
+++ b/next/nextTape.css
@@ -67,6 +67,18 @@ body {
     border: 1px solid rgba(0, 0, 0, 0.2);
 }
 
+#track-title {
+    font-family: 'Permanent Marker', cursive;
+    font-size: 1.2rem;
+    color: #fff;
+    text-shadow:
+        2px 2px 4px rgba(0, 0, 0, 0.8),
+        -1px -1px 2px rgba(0, 0, 0, 0.5);
+    margin: 10px 0;
+    padding: 5px;
+    letter-spacing: 0.5px;
+    line-height: 1.4;
+}
 
 .reels {
     position: absolute;


### PR DESCRIPTION
## Summary
Adds a graffiti-style handwritten font to the active track display on the cassette player for a more authentic mixtape aesthetic.

## Changes
- Import "Permanent Marker" font from Google Fonts
- Apply handwriting style to #track-title element
- Add text shadows for depth and visual impact
- Maintain monospace font for j-card track listing

## Visual improvements
- Active track now displays in graffiti-style handwriting
- Text shadows create depth against dark cassette background
- Authentic mixtape feel with handwritten track names
- Track listing retains clean monospace for readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)